### PR TITLE
chore: remove private flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@auth0/auth0-hono",
   "version": "1.0.0",
   "description": "Auth0 Authentication middleware for Hono",
-  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The `private` field has been removed, which may indicate that the package is now intended for public distribution.