### PR TITLE
fix(config): actually use passed authorizationParams

### DIFF
--- a/src/config/envConfig.ts
+++ b/src/config/envConfig.ts
@@ -47,15 +47,17 @@ export const assignFromEnv = (
     BASE_URL,
     AUTH0_AUDIENCE,
   } = env;
+
+  const authorizationParams = {...configWithoutEnv.authorizationParams};
+  authorizationParams.audience = authorizationParams.audience ?? AUTH0_AUDIENCE;
+
   return {
     ...configWithoutEnv,
     domain: configWithoutEnv.domain ?? AUTH0_DOMAIN,
     clientID: configWithoutEnv.clientID ?? AUTH0_CLIENT_ID,
     clientSecret: configWithoutEnv.clientSecret ?? AUTH0_CLIENT_SECRET,
     baseURL: configWithoutEnv.baseURL ?? BASE_URL,
-    authorizationParams: AUTH0_AUDIENCE
-      ? { audience: AUTH0_AUDIENCE }
-      : undefined,
+    authorizationParams: authorizationParams,
     session: {
       ...(configWithoutEnv.session || {}),
       secret:

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import { parseConfiguration } from "../src/config";
 import { InitConfiguration } from "../src/config/Configuration";
+import { assignFromEnv } from "../src/config/envConfig";
 
 describe("Configuration Parser", () => {
   it("should parse a valid configuration", () => {
@@ -91,5 +92,142 @@ describe("Configuration Parser", () => {
     };
 
     expect(() => parseConfiguration(config)).toThrow();
+  });
+});
+
+describe("Environment Configuration", () => {
+  describe("assignFromEnv", () => {
+    const validEnv = {
+      AUTH0_DOMAIN: "test.auth0.com",
+      AUTH0_CLIENT_ID: "test-client-id",
+      BASE_URL: "https://example.com",
+      AUTH0_CLIENT_SECRET: "test-secret",
+      AUTH0_AUDIENCE: "https://api.example.com",
+    };
+
+    it("should assign audience from env to authorizationParams when audience only exists in env and not config", () => {
+      const config = {};
+      const env = validEnv;
+
+      const result = assignFromEnv(config, env);
+
+      expect(result.authorizationParams).toEqual({
+        audience: "https://api.example.com",
+      });
+    });
+
+    it("should prioritize config authorizationParams.audience over env audience when both exist", () => {
+      const config = {
+        authorizationParams: {
+          audience: "https://config-audience.com",
+          scope: "openid profile",
+        },
+      };
+      const env = validEnv;
+
+      const result = assignFromEnv(config, env);
+
+      expect(result.authorizationParams).toEqual({
+        audience: "https://config-audience.com",
+        scope: "openid profile",
+      });
+    });
+
+    it("should propagate all other authorizationParams from config and merge with env audience if there is no config audience", () => {
+      const config = {
+        authorizationParams: {
+          scope: "openid profile email",
+          prompt: "login",
+          max_age: 3600,
+          ui_locales: "en-US",
+        },
+      };
+      const env = validEnv;
+
+      const result = assignFromEnv(config, env);
+
+      expect(result.authorizationParams).toEqual({
+        scope: "openid profile email",
+        prompt: "login",
+        max_age: 3600,
+        ui_locales: "en-US",
+        audience: "https://api.example.com",
+      });
+    });
+
+    it("should assign env audience when config has empty authorizationParams object", () => {
+      const config = {
+        authorizationParams: {},
+      };
+      const env = validEnv;
+
+      const result = assignFromEnv(config, env);
+
+      expect(result.authorizationParams).toEqual({
+        audience: "https://api.example.com",
+      });
+    });
+
+    it("should assign env audience when config has no authorizationParams defined", () => {
+      const config = {};
+      const env = validEnv;
+
+      const result = assignFromEnv(config, env);
+
+      expect(result.authorizationParams).toEqual({
+        audience: "https://api.example.com",
+      });
+    });
+
+    it("should not set audience when audience is absent from both env and config", () => {
+      const config = {
+        authorizationParams: {
+          scope: "openid profile",
+        },
+      };
+      const envWithoutAudience = {
+        AUTH0_DOMAIN: "test.auth0.com",
+        AUTH0_CLIENT_ID: "test-client-id",
+        BASE_URL: "https://example.com",
+      };
+
+      const result = assignFromEnv(config, envWithoutAudience);
+
+      expect(result.authorizationParams).toEqual({
+        scope: "openid profile",
+      });
+    });
+
+    it("should handle undefined config gracefully and use env values", () => {
+      const config = undefined;
+      const env = validEnv;
+
+      const result = assignFromEnv(config, env);
+
+      expect(result.authorizationParams).toEqual({
+        audience: "https://api.example.com",
+      });
+      expect(result.domain).toBe("test.auth0.com");
+      expect(result.clientID).toBe("test-client-id");
+      expect(result.baseURL).toBe("https://example.com");
+    });
+
+    it("should return config as-is when env doesn't have required fields", () => {
+      const config = {
+        domain: "config.auth0.com",
+        clientID: "config-client-id",
+        authorizationParams: {
+          scope: "openid profile",
+        },
+      };
+      const invalidEnv = {
+        // Missing required AUTH0_DOMAIN, AUTH0_CLIENT_ID, BASE_URL
+        AUTH0_AUDIENCE: "https://api.example.com",
+      };
+
+      const result = assignFromEnv(config, invalidEnv);
+
+      expect(result).toEqual(config);
+    });
   });
 });


### PR DESCRIPTION
Before this fix there is no way to set `authorizationParams` from code.

Example:
```
app.use(
  auth({
    authRequired: false,
    idpLogout: true,
    authorizationParams: {
      scope: “openid profile email offline_access”,
    },
  ```

`scope` would be ignored. Same for all other props. Moreover, you can only pass AUTH0_AUDIENCE via .env file but nothing else. In essence: audience can only be set, and it can only be set from .env.

 This PR fixes that.