### PR TITLE
fix: publish config

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "hono": ">=3.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   }
 }


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` file, adding a `tag` field with the value `latest` to the `publishConfig` section. This ensures that when the package is published, it will be tagged as the latest version on the package registry.