### PR TITLE
fix(security): run npm ci with --ignore-scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           scope: "@auth0"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Validate Commits Messages
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This would avoid malicious scripts in vulnerable packages to be executed on CI