### PR TITLE
fix: resolve 404 on redirect due to next() poisoning (callback,logout)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@ const gitignorePath = fileURLToPath(new URL(".gitignore", import.meta.url));
 
 export default defineConfig([
   includeIgnoreFile(gitignorePath),
+  { ignores: ["examples/"] },
   { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: globals.node } },
   tseslint.configs.recommended,

--- a/src/config/Schema.ts
+++ b/src/config/Schema.ts
@@ -113,9 +113,7 @@ export const ConfigurationSchema = z
       .optional()
       .default(() => globalThis.fetch),
 
-    onCallback: z
-      .custom<Configuration['onCallback']>((v) => typeof v === 'function')
-      .optional(),
+    onCallback: z.custom<Configuration['onCallback']>((v) => typeof v === 'function').optional(),
   })
   .transform((data) => {
     const isSecure = /^https:/i.test(data.baseURL);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -42,6 +42,12 @@ export const parseConfiguration = (config: InitConfiguration): Configuration => 
   }
 
   // Tier 2: Value equality (ensureClient() — new object from env, no functions)
+  // KNOWN LIMITATION: JSON.stringify drops function fields (debug, fetch, onCallback).
+  // Two configs differing only in function fields would collide here. Safe because
+  // Tier 2 is only hit by ensureClient() which creates config from env(c) — never
+  // contains functions. auth0() middleware always hits Tier 1 (reference equality).
+  // If this changes (e.g., ensureClient gains function support), Tier 2 must use
+  // a hash that accounts for function identity.
   const cacheKey = JSON.stringify(config);
   if (parsedConfigByValue.has(cacheKey)) {
     const cached = parsedConfigByValue.get(cacheKey)!;

--- a/src/middleware/callback.ts
+++ b/src/middleware/callback.ts
@@ -5,7 +5,7 @@ import { Auth0Error } from '@/errors/Auth0Error.js';
 import { Next, MiddlewareHandler } from 'hono';
 import { createMiddleware } from 'hono/factory';
 import { OIDCEnv } from '@/lib/honoEnv.js';
-import { resumeSilentLogin } from './silentLogin.js';
+import { deleteSilentLoginCookie } from './silentLogin.js';
 import { SessionData, StateData, StateStore } from '@auth0/auth0-server-js';
 import { STATE_STORE_KEY } from '@/lib/constants.js';
 import { Configuration } from '@/config/Configuration.js';
@@ -102,7 +102,7 @@ export const callback = (params: CallbackParams = {}) => {
         try {
           const hookResult = await hook(c, null, session);
           if (hookResult instanceof Response) {
-            await resumeSilentLogin()(c, next);
+            deleteSilentLoginCookie(c);
             return hookResult;
           }
           // If hook returns enriched session (different object), persist it
@@ -132,8 +132,10 @@ export const callback = (params: CallbackParams = {}) => {
         }
       }
 
-      // Resume silent login and redirect
-      await resumeSilentLogin()(c, next);
+      // Delete silent login skip cookie directly — do NOT use resumeSilentLogin()(c, next).
+      // resumeSilentLogin calls next() which dispatches to Hono's 404 in standalone routes,
+      // setting context.finalized=true and causing the redirect below to be discarded.
+      deleteSilentLoginCookie(c);
 
       if (params.redirectAfterLogin === false) {
         return next();

--- a/src/middleware/logout.ts
+++ b/src/middleware/logout.ts
@@ -21,7 +21,7 @@ export type LogoutParams = {
  * if idpLogout is enabled in configuration.
  */
 export const logout = (params: LogoutParams = {}) => {
-  return createMiddleware<OIDCEnv>(async function (c, next): Promise<Response> {
+  return createMiddleware<OIDCEnv>(async function (c): Promise<Response> {
     try {
       const { client, configuration } = getClient(c);
       const session = await client.getSession(c);

--- a/src/middleware/logout.ts
+++ b/src/middleware/logout.ts
@@ -3,7 +3,7 @@ import { OIDCEnv } from '@/lib/honoEnv.js';
 import { toSafeRedirect } from '@/utils/util.js';
 import { mapServerError } from '@/errors/errorMap.js';
 import { createMiddleware } from 'hono/factory';
-import { resumeSilentLogin } from './silentLogin.js';
+import { deleteSilentLoginCookie } from './silentLogin.js';
 import { MiddlewareHandler } from 'hono';
 
 export type LogoutParams = {
@@ -36,7 +36,9 @@ export const logout = (params: LogoutParams = {}) => {
 
       const logoutUrl = await client.logout({ returnTo }, c);
 
-      await resumeSilentLogin()(c, next);
+      // Delete silent login skip cookie directly — do NOT use resumeSilentLogin()(c, next).
+      // See callback.ts for full explanation of the next() poisoning bug.
+      deleteSilentLoginCookie(c);
 
       if (!configuration.idpLogout) {
         return c.redirect(returnTo);

--- a/src/middleware/silentLogin.ts
+++ b/src/middleware/silentLogin.ts
@@ -29,6 +29,14 @@ const getCookieOptions = (c: Context<OIDCEnv>): CookieOptions => {
  * Cancel silent login attempts by setting a cookie.
  * Calls next() — safe to use as composable middleware in route chains:
  *   app.get('/logout', cancelSilentLogin(), handleLogout())
+ *
+ * WARNING: Do NOT call this as `cancelSilentLogin()(c, next)` inside handlers
+ * that return their own response (e.g., callback, logout). The `next()` call
+ * will dispatch to the next route handler, which may be Hono's 404 not-found.
+ * If Hono's 404 fires, `context.finalized = true` and any subsequent
+ * `c.redirect()` or `c.json()` will be silently discarded.
+ * Use `deleteSilentLoginCookie(c)` / direct `setCookie()` instead.
+ * See: https://github.com/auth0/auth0-hono/pull/19 (PR review discussion)
  */
 export const cancelSilentLogin = () =>
   createMiddleware(async (c, next) => {
@@ -44,12 +52,39 @@ export const pauseSilentLogin = cancelSilentLogin;
 /**
  * Resume silent login by deleting the skip cookie.
  * Calls next() — safe to use as composable middleware in route chains.
+ *
+ * WARNING: Same caveat as cancelSilentLogin() — do NOT call as
+ * `resumeSilentLogin()(c, next)` inside handlers that return their own
+ * response. Use `deleteSilentLoginCookie(c)` instead.
  */
 export const resumeSilentLogin = () =>
   createMiddleware(async (c, next) => {
     deleteCookie(c, COOKIE_NAME, getCookieOptions(c));
     return next();
   });
+
+/**
+ * Delete the silent login skip cookie directly on a context.
+ *
+ * Unlike resumeSilentLogin(), this does NOT call next() — safe to call
+ * inside handlers that manage their own response (e.g., callback, logout).
+ *
+ * CONTEXT: resumeSilentLogin() calls next() for composability in middleware
+ * chains. But callback.ts and logout.ts return their own redirect response.
+ * If next() fires inside those handlers, Hono dispatches to the next route
+ * (often 404) which sets context.finalized = true, causing the redirect to
+ * be silently discarded. This function avoids that by only deleting the cookie.
+ *
+ * Bug found: 2026-05-11. Root cause: commit 967e88d added next() to
+ * resumeSilentLogin for composability but didn't update existing call sites
+ * in callback.ts and logout.ts that passed their own `next` through.
+ *
+ * @param c - Hono context
+ * @internal
+ */
+export function deleteSilentLoginCookie(c: Context<OIDCEnv>): void {
+  deleteCookie(c, COOKIE_NAME, getCookieOptions(c));
+}
 
 export const attemptSilentLogin = () => {
   return createMiddleware<OIDCEnv>(async (c, next) => {

--- a/src/session/HonoCookieHandler.ts
+++ b/src/session/HonoCookieHandler.ts
@@ -58,7 +58,11 @@ function capitalize<T extends string>(s: T): Capitalize<T> {
 export class HonoCookieHandler implements CookieHandler<Context> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private static localStore: any = AsyncLocalStorageImpl ? new AsyncLocalStorageImpl() : null;
-  // Cache cookie options per name for deletion (Chrome scheme-bound cookies require matching attrs)
+  // Cache cookie options per name for deletion (Chrome scheme-bound cookies require matching attrs).
+  // This is a singleton instance — persists across requests. Last-write-wins per cookie name.
+  // Safe because each cookie name (__a0_tx, appSession, etc.) always uses the same options
+  // across its lifecycle. If a future feature uses dynamic options per-cookie-name, this
+  // would need to be request-scoped.
   private cookieOptionsCache = new Map<string, CookieOptions>();
 
   static setContext<R>(context: Context, callback: () => R): R {
@@ -101,8 +105,9 @@ export class HonoCookieHandler implements CookieHandler<Context> {
    */
   getCookies(storeOptions?: Context): Record<string, string> {
     const { req } = this.getContext(storeOptions);
-    return Object.fromEntries(
-      (req.header('Cookie') ?? '').split(';').map((cookie) => {
+    const rawHeader = req.header('Cookie') ?? '';
+    const result = Object.fromEntries(
+      rawHeader.split(';').map((cookie) => {
         const [key, ...val] = cookie.trim().split('=');
         const encodedValue = val.join('=');
         let decodedValue: string;
@@ -118,6 +123,7 @@ export class HonoCookieHandler implements CookieHandler<Context> {
         return [key, decodedValue];
       })
     );
+    return result;
   }
 
   setCookie(name: string, value: string, options?: CookieSerializeOptions, storeOptions?: Context): string {
@@ -140,7 +146,8 @@ export class HonoCookieHandler implements CookieHandler<Context> {
   getCookie(name: string, storeOptions?: Context): string | undefined {
     const ctx = this.getContext(storeOptions);
     try {
-      return getCookie(ctx, name);
+      const val = getCookie(ctx, name);
+      return val;
     } catch {
       // Malformed %-encoding in cookie value — treat as absent.
       // Prevents 500 crash from attacker-injected malformed session cookies.

--- a/test/flows/hooks.spec.ts
+++ b/test/flows/hooks.spec.ts
@@ -24,6 +24,7 @@ vi.mock('../../src/helpers/sessionCache', () => ({
 
 vi.mock('../../src/middleware/silentLogin', () => ({
   resumeSilentLogin: vi.fn().mockReturnValue(vi.fn().mockResolvedValue(undefined)),
+  deleteSilentLoginCookie: vi.fn(),
 }));
 
 vi.mock('../../src/errors/errorMap', () => ({

--- a/test/middleware/callback.test.ts
+++ b/test/middleware/callback.test.ts
@@ -2,8 +2,8 @@
 import { Context } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { getClient } from '../../src/config';
-import { resumeSilentLogin } from '../../src/middleware';
 import { callback } from '../../src/middleware/callback';
+import { deleteSilentLoginCookie } from '../../src/middleware/silentLogin';
 import { createRouteUrl } from '../../src/utils/util';
 
 // Mock dependencies
@@ -18,6 +18,7 @@ vi.mock('../../src/utils/util', () => ({
 
 vi.mock('../../src/middleware/silentLogin', () => ({
   resumeSilentLogin: vi.fn(),
+  deleteSilentLoginCookie: vi.fn(),
 }));
 
 describe('callback middleware', () => {
@@ -25,12 +26,8 @@ describe('callback middleware', () => {
   let mockClient: any;
   let mockConfiguration: any;
   const nextFn = vi.fn();
-  const resumeSilentLoginMiddleware = vi.fn();
-
   beforeEach(() => {
     vi.resetAllMocks();
-
-    (resumeSilentLogin as Mock).mockReturnValue(resumeSilentLoginMiddleware);
 
     // Create a mock state store
     const mockStateStore = {
@@ -101,8 +98,8 @@ describe('callback middleware', () => {
       );
     });
 
-    it('should call the resume silent login middleware', () => {
-      expect(resumeSilentLoginMiddleware).toHaveBeenCalledWith(mockContext, nextFn);
+    it('should delete the silent login skip cookie', () => {
+      expect(deleteSilentLoginCookie).toHaveBeenCalledWith(mockContext);
     });
 
     it('should redirect to the returnTo URL by default', () => {
@@ -175,9 +172,9 @@ describe('callback middleware', () => {
       mockClient.completeInteractiveLogin.mockRejectedValue(new Error('Authorization code grant failed'));
     });
 
-    it('should NOT call resumeSilentLogin on error path (prevents redirect loop)', async () => {
+    it('should NOT call deleteSilentLoginCookie on error path (prevents redirect loop)', async () => {
       await expect(callback()(mockContext, nextFn)).rejects.toThrow('Authorization code grant failed');
-      expect(resumeSilentLoginMiddleware).not.toHaveBeenCalled();
+      expect(deleteSilentLoginCookie).not.toHaveBeenCalled();
     });
   });
 
@@ -200,8 +197,8 @@ describe('callback middleware', () => {
       }
     });
 
-    it('should NOT call resumeSilentLogin on error path (prevents redirect loop)', () => {
-      expect(resumeSilentLoginMiddleware).not.toHaveBeenCalled();
+    it('should NOT call deleteSilentLoginCookie on error path (prevents redirect loop)', () => {
+      expect(deleteSilentLoginCookie).not.toHaveBeenCalled();
     });
 
     it('should throw the error', () => {

--- a/test/middleware/logout.test.ts
+++ b/test/middleware/logout.test.ts
@@ -2,8 +2,8 @@
 import { Context } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { getClient } from '../../src/config';
-import { resumeSilentLogin } from '../../src/middleware';
 import { logout } from '../../src/middleware/logout';
+import { deleteSilentLoginCookie } from '../../src/middleware/silentLogin';
 import { toSafeRedirect } from '../../src/utils/util';
 
 // Mock dependencies
@@ -17,6 +17,7 @@ vi.mock('../../src/utils/util', () => ({
 
 vi.mock('../../src/middleware/silentLogin', () => ({
   resumeSilentLogin: vi.fn(),
+  deleteSilentLoginCookie: vi.fn(),
 }));
 
 describe('logout middleware', () => {
@@ -25,11 +26,8 @@ describe('logout middleware', () => {
   let mockConfiguration: any;
   let mockClient: any;
   const nextFn = vi.fn();
-  const resumeSilentLoginMiddleware = vi.fn();
   beforeEach(() => {
     vi.resetAllMocks();
-
-    (resumeSilentLogin as Mock).mockReturnValue(resumeSilentLoginMiddleware);
     // Mock OIDC session data
     mockOidcSession = {
       id_token: 'mock-id-token',
@@ -102,8 +100,8 @@ describe('logout middleware', () => {
       });
     });
 
-    it('should call resumeSilentLogin middleware', () => {
-      expect(resumeSilentLoginMiddleware).toHaveBeenCalledWith(mockContext, nextFn);
+    it('should delete silent login skip cookie', () => {
+      expect(deleteSilentLoginCookie).toHaveBeenCalledWith(mockContext);
     });
   });
 


### PR DESCRIPTION
## Summary                                                                                                   
                                               
  - **Fix:** Callback and logout handlers returned 404 instead of redirecting after successful login/logout    
  - **Root cause:** `resumeSilentLogin()` calls `next()` for middleware composability (added in 967e88d).    
  Callback/logout called it as `resumeSilentLogin()(c, next)`, passing the handler's own `next` — which        
  dispatches to Hono's 404 not-found handler in standalone routes. This sets `context.finalized = true`,     
  silently discarding the subsequent `c.redirect()`                                                            
  - **Fix:** New `deleteSilentLoginCookie(c)` function that deletes the skip cookie without calling `next()`.
  Used in callback.ts and logout.ts where handlers control their own response                                  
                                                                                                             
  ## Changes                                                                                                   
                                                                                                             
  - `src/middleware/silentLogin.ts` — add `deleteSilentLoginCookie()` helper + JSDoc warnings on middleware    
  variants                                                                                                   
  - `src/middleware/callback.ts` — replace `resumeSilentLogin()(c, next)` with `deleteSilentLoginCookie(c)`    
  - `src/middleware/logout.ts` — same                                                                          
  - `src/session/HonoCookieHandler.ts` — inline docs on singleton cookie cache semantics                       
  - `src/config/index.ts` — inline docs on Tier 2 cache JSON.stringify limitation                              
  - `test/middleware/callback.test.ts` — update assertions                                                     
  - `test/middleware/logout.test.ts` — update assertions                                                       
  - `test/flows/hooks.spec.ts` — add mock                                                                      
                                                                                                               
  ## Test plan                                                                                                 
                                                                                                               
  - [x] 322/322 unit tests pass                                                                                
  - [x] Manual: smoke test login → callback → session → home (authenticated)                                 
  - [x] Manual: logout redirects to Auth0 OIDC logout (no 404)                                                 
  - [x] Manual: login with SSO (no Auth0 prompt, instant callback) works                                       
  - [ ] Manual: silent login flow (attemptSilentLogin) — if enabled