### PR TITLE
Release v2.0.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Change Log
 
-## [v2.0.0-beta.0](https://github.com/auth0/auth0-hono/tree/v2.0.0-beta.0) (2026-05-13)
+## [v2.0.0-beta.0](https://github.com/auth0/auth0-hono/tree/v2.0.0-beta.0) (2026-05-29)
 
 **Added**
-- feat: beta release - OIDC helpers, authorization middleware, typed errors, multi-runtime support [\#17](https://github.com/auth0/auth0-hono/pull/17) ([tusharpandey13](https://github.com/tusharpandey13))
+- feat: beta release - OIDC helpers, authorization middleware, typed errors, multi-runtime support [#17](https://github.com/auth0/auth0-hono/pull/17) ([tusharpandey13](https://github.com/tusharpandey13))
 
 **Fixed**
-- fix: resolve 404 on redirect due to next() poisoning (callback,logout) [\#20](https://github.com/auth0/auth0-hono/pull/20) ([tusharpandey13](https://github.com/tusharpandey13))
+- fix: resolve 404 on redirect due to next() poisoning (callback, logout) [#20](https://github.com/auth0/auth0-hono/pull/20) ([tusharpandey13](https://github.com/tusharpandey13))
+- fix(security): harden config cache, block max_age, document accepted risks [#23](https://github.com/auth0/auth0-hono/pull/23) ([tusharpandey13](https://github.com/tusharpandey13))
+- fix(callback): replace per-request monkey-patch with WeakMap capture [#28](https://github.com/auth0/auth0-hono/pull/28) ([tusharpandey13](https://github.com/tusharpandey13))
+- fix: Security hardening [#29](https://github.com/auth0/auth0-hono/pull/29) ([tusharpandey13](https://github.com/tusharpandey13))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+## [v2.0.0-beta.0](https://github.com/auth0/auth0-hono/tree/v2.0.0-beta.0) (2026-05-13)
+
+**Added**
+- feat: beta release - OIDC helpers, authorization middleware, typed errors, multi-runtime support [\#17](https://github.com/auth0/auth0-hono/pull/17) ([tusharpandey13](https://github.com/tusharpandey13))
+
+**Fixed**
+- fix: resolve 404 on redirect due to next() poisoning (callback,logout) [\#20](https://github.com/auth0/auth0-hono/pull/20) ([tusharpandey13](https://github.com/tusharpandey13))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/auth0-hono",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/auth0-hono",
-      "version": "1.0.0",
+      "version": "2.0.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@auth0/auth0-server-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-hono",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "Auth0 Authentication middleware for Hono",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## [v2.0.0-beta.0](https://github.com/auth0/auth0-hono/tree/v2.0.0-beta.0) (2026-05-29) 

**Added** 
- feat: beta release - OIDC helpers, authorization middleware, typed errors, multi-runtime support [#17](https://github.com/auth0/auth0-hono/pull/17) ([tusharpandey13](https://github.com/tusharpandey13))

**Fixed** 
- fix: resolve 404 on redirect due to next() poisoning (callback, logout) [#20](https://github.com/auth0/auth0-hono/pull/20) ([tusharpandey13](https://github.com/tusharpandey13)) 
- fix(security): harden config cache, block max_age, document accepted risks [#23](https://github.com/auth0/auth0-hono/pull/23) ([tusharpandey13](https://github.com/tusharpandey13)) 
- fix(callback): replace per-request monkey-patch with WeakMap capture [#28](https://github.com/auth0/auth0-hono/pull/28)  ([tusharpandey13](https://github.com/tusharpandey13)) 
- fix: Security hardening [#29](https://github.com/auth0/auth0-hono/pull/29) ([tusharpandey13](https://github.com/tusharpandey13)) 