### PR TITLE
fix: replace per-request session patch with WeakMap capture

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -88,6 +88,7 @@ export function createStateStore(config: Configuration, cookieHandler: HonoCooki
 export function initializeOidcClient(config: Configuration): Auth0ClientBundle {
   const cookieHandler = new HonoCookieHandler();
   const stateStore = createStateStore(config, cookieHandler);
+  const stateId = config.session.cookie?.name ?? 'appSession';
 
   const serverClient = new ServerClient<Context>({
     domain: config.domain,
@@ -106,15 +107,14 @@ export function initializeOidcClient(config: Configuration): Auth0ClientBundle {
       cookieHandler
     ),
     stateStore, // Same reference retained below
-    stateIdentifier: config.session.cookie?.name ?? 'appSession',
+    stateIdentifier: stateId,
     customFetch: config.fetch,
   });
 
   // Install one-time capture interceptor for concurrency-safe session capture.
   // This replaces the per-request monkey-patch pattern in callback.ts that was
   // vulnerable to race conditions under concurrent OAuth callbacks.
-  const stateIdentifier = config.session.cookie?.name ?? 'appSession';
-  installCaptureInterceptor(stateStore, stateIdentifier);
+  installCaptureInterceptor(stateStore, stateId);
 
   // RETURN: Bundle with retained state store reference
   return { serverClient, stateStore, cookieHandler };

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,5 +1,6 @@
 import { Configuration } from '@/config/Configuration.js';
 import { HonoCookieHandler } from '@/session/HonoCookieHandler.js';
+import { installCaptureInterceptor } from '@/session/captureRegistry.js';
 import { createRouteUrl } from '@/utils/util.js';
 
 /** Resolve secret to string (first element if array — active encryption key). */
@@ -108,6 +109,12 @@ export function initializeOidcClient(config: Configuration): Auth0ClientBundle {
     stateIdentifier: config.session.cookie?.name ?? 'appSession',
     customFetch: config.fetch,
   });
+
+  // Install one-time capture interceptor for concurrency-safe session capture.
+  // This replaces the per-request monkey-patch pattern in callback.ts that was
+  // vulnerable to race conditions under concurrent OAuth callbacks.
+  const stateIdentifier = config.session.cookie?.name ?? 'appSession';
+  installCaptureInterceptor(stateStore, stateIdentifier);
 
   // RETURN: Bundle with retained state store reference
   return { serverClient, stateStore, cookieHandler };

--- a/src/middleware/callback.ts
+++ b/src/middleware/callback.ts
@@ -4,6 +4,7 @@ import { Auth0Error } from '@/errors/Auth0Error.js';
 import { mapServerError } from '@/errors/errorMap.js';
 import { STATE_STORE_KEY } from '@/lib/constants.js';
 import { OIDCEnv } from '@/lib/honoEnv.js';
+import { clearCapturedState, getCapturedState } from '@/session/captureRegistry.js';
 import { createRouteUrl, toSafeRedirect } from '@/utils/util.js';
 import { SessionData, StateData, StateStore } from '@auth0/auth0-server-js';
 import { Context, MiddlewareHandler, Next } from 'hono';
@@ -59,32 +60,22 @@ export const callback = (params: CallbackParams = {}) => {
       // Capture the session that completeInteractiveLogin persists.
       // We can't re-read from cookies because setCookie writes to response headers
       // but getCookie reads from the request Cookie header (stale on callback request).
-      // We intercept stateStore.set() to capture the written StateData in memory.
       //
-      // Concurrency note:
-      // This patches a shared singleton stateStore for ~50ms (duration of completeInteractiveLogin).
-      // The patch uses request-scoped `identifier` matching to isolate captures.
+      // Session capture uses a WeakMap-based registry (installed once at init in client.ts)
+      // keyed by the per-request Hono Context. This provides concurrency-safe isolation
+      // without per-request monkey-patching of the shared stateStore singleton.
+      // See: src/session/captureRegistry.ts
       const { stateStore, identifier } = getStateStoreContext(c, configuration);
-      let capturedStateData: StateData | null = null;
-      const originalSet = stateStore.set;
-      stateStore.set = async function (this: StateStore<Context>, id, data, removeIfExists, opts) {
-        if (id === identifier) {
-          capturedStateData = data as StateData;
-        }
-        return originalSet.call(this, id, data, removeIfExists, opts);
-      };
 
-      let appState: { returnTo: string } | undefined;
-      try {
-        // Complete the login flow
-        ({ appState } = await client.completeInteractiveLogin<{ returnTo: string } | undefined>(
-          createRouteUrl(c.req.url, baseURL),
-          c
-        ));
-      } finally {
-        // Always restore — even if completeInteractiveLogin throws
-        stateStore.set = originalSet;
-      }
+      // Complete the login flow
+      const { appState } = await client.completeInteractiveLogin<{ returnTo: string } | undefined>(
+        createRouteUrl(c.req.url, baseURL),
+        c
+      );
+
+      // Retrieve captured state from the per-request registry slot
+      const capturedStateData = getCapturedState(c) ?? null;
+      clearCapturedState(c);
 
       // Use captured session (strips internal to match SessionData contract)
       if (capturedStateData) {

--- a/src/session/captureRegistry.ts
+++ b/src/session/captureRegistry.ts
@@ -1,0 +1,91 @@
+import { StateData, StateStore } from '@auth0/auth0-server-js';
+import { Context } from 'hono';
+
+/**
+ * Per-request session capture registry.
+ *
+ * Solves a concurrency race condition in the callback handler:
+ * `completeInteractiveLogin` writes session data via `stateStore.set`, but we
+ * cannot re-read it from cookies (setCookie writes to response headers;
+ * getCookie reads from request headers — stale on callback request).
+ *
+ * Previous approach: monkey-patch `stateStore.set` per-request and restore after.
+ * Under concurrent callbacks, nested patches corrupt the restore chain, causing
+ * cross-request session data leakage when an `onCallback` hook enriches session.
+ *
+ * Current approach: install a single permanent interceptor at init time.
+ * Use a WeakMap keyed by Hono Context (unique per-request object) to isolate
+ * captured session data per request. No per-request patching/unpatching needed.
+ *
+ * WeakMap guarantees:
+ * - Object identity isolation (each request has unique Context)
+ * - Automatic GC when Context is collected (no memory leak)
+ * - O(1) operations with negligible overhead (~100ns per set call)
+ *
+ * @internal
+ */
+const captureRegistry = new WeakMap<Context, StateData>();
+
+/**
+ * Symbol guard to prevent double-installation of the interceptor.
+ * @internal
+ */
+const INTERCEPTOR_INSTALLED = Symbol('captureInterceptorInstalled');
+
+/**
+ * Install a one-time interceptor on the stateStore that captures written
+ * StateData into a per-request WeakMap slot.
+ *
+ * Safe to call multiple times — subsequent calls are no-ops.
+ *
+ * @param stateStore - The shared StateStore singleton
+ * @param identifier - The session cookie name (e.g. 'appSession')
+ * @internal
+ */
+export function installCaptureInterceptor(stateStore: StateStore<Context>, identifier: string): void {
+  if ((stateStore as unknown as Record<symbol, boolean>)[INTERCEPTOR_INSTALLED]) {
+    return;
+  }
+
+  const originalSet = stateStore.set.bind(stateStore);
+  stateStore.set = async function (
+    id: string,
+    data: StateData,
+    removeIfExists?: boolean,
+    opts?: Context
+  ): Promise<void> {
+    if (id === identifier && opts) {
+      captureRegistry.set(opts, data);
+    }
+    return originalSet(id, data, removeIfExists, opts);
+  };
+
+  (stateStore as unknown as Record<symbol, boolean>)[INTERCEPTOR_INSTALLED] = true;
+}
+
+/**
+ * Retrieve captured StateData for a specific request context.
+ *
+ * Returns the StateData written by `completeInteractiveLogin` for this request,
+ * or undefined if no capture occurred (e.g. login failed before reaching set).
+ *
+ * @param c - The Hono Context for the current request
+ * @returns Captured StateData or undefined
+ * @internal
+ */
+export function getCapturedState(c: Context): StateData | undefined {
+  return captureRegistry.get(c);
+}
+
+/**
+ * Clear captured StateData for a specific request context.
+ *
+ * Call after reading to ensure no stale references remain for the request
+ * duration. WeakMap would GC eventually, but explicit cleanup is immediate.
+ *
+ * @param c - The Hono Context for the current request
+ * @internal
+ */
+export function clearCapturedState(c: Context): void {
+  captureRegistry.delete(c);
+}

--- a/src/session/captureRegistry.ts
+++ b/src/session/captureRegistry.ts
@@ -32,6 +32,9 @@ const captureRegistry = new WeakMap<Context, StateData>();
  */
 const INTERCEPTOR_INSTALLED = Symbol('captureInterceptorInstalled');
 
+/** @internal Type augmentation for Symbol guard on stateStore instance */
+type GuardedStore = StateStore<Context> & { [key: symbol]: boolean };
+
 /**
  * Install a one-time interceptor on the stateStore that captures written
  * StateData into a per-request WeakMap slot.
@@ -43,7 +46,7 @@ const INTERCEPTOR_INSTALLED = Symbol('captureInterceptorInstalled');
  * @internal
  */
 export function installCaptureInterceptor(stateStore: StateStore<Context>, identifier: string): void {
-  if ((stateStore as unknown as Record<symbol, boolean>)[INTERCEPTOR_INSTALLED]) {
+  if ((stateStore as GuardedStore)[INTERCEPTOR_INSTALLED]) {
     return;
   }
 
@@ -60,7 +63,7 @@ export function installCaptureInterceptor(stateStore: StateStore<Context>, ident
     return originalSet(id, data, removeIfExists, opts);
   };
 
-  (stateStore as unknown as Record<symbol, boolean>)[INTERCEPTOR_INSTALLED] = true;
+  (stateStore as GuardedStore)[INTERCEPTOR_INSTALLED] = true;
 }
 
 /**

--- a/test/flows/hooks.spec.ts
+++ b/test/flows/hooks.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { callback } from '../../src/middleware/callback';
 import { SessionData } from '@auth0/auth0-server-js';
 import { Auth0Error } from '../../src/errors/Auth0Error';
+import { installCaptureInterceptor } from '../../src/session/captureRegistry';
 import { createMockContext, createMockClient, createMockConfig, createMockSession } from '../fixtures';
 
 // Mock dependencies
@@ -37,6 +38,7 @@ describe('onCallback Hook', () => {
   let mockClient: any;
   let mockSession: SessionData;
   let mockStateStore: any;
+  let mockStateStoreSetSpy: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -78,6 +80,12 @@ describe('onCallback Hook', () => {
     });
 
     // Set up mock stateStore with contract-enforcing set
+    mockStateStoreSetSpy = vi.fn().mockImplementation(async (_id: string, stateData: any) => {
+      // Enforce contract: internal.createdAt must exist
+      if (!stateData?.internal?.createdAt) {
+        throw new TypeError("Cannot read properties of undefined (reading 'createdAt')");
+      }
+    });
     mockStateStore = {
       get: vi.fn().mockResolvedValue({
         ...mockSession,
@@ -86,13 +94,13 @@ describe('onCallback Hook', () => {
           createdAt: Math.floor(Date.now() / 1000),
         },
       }),
-      set: vi.fn().mockImplementation(async (_id: string, stateData: any) => {
-        // Enforce contract: internal.createdAt must exist
-        if (!stateData?.internal?.createdAt) {
-          throw new TypeError("Cannot read properties of undefined (reading 'createdAt')");
-        }
-      }),
+      set: mockStateStoreSetSpy,
+      delete: vi.fn(),
     };
+    // Install capture interceptor on mock stateStore (same as real init in client.ts)
+    // Note: this replaces mockStateStore.set with the interceptor, which internally
+    // delegates to mockStateStoreSetSpy. Use mockStateStoreSetSpy for call assertions.
+    installCaptureInterceptor(mockStateStore, 'appSession');
     mockContext.vars['__auth0_state_store'] = mockStateStore;
 
     mockContext.get = vi.fn((key: string) => {
@@ -149,7 +157,7 @@ describe('onCallback Hook', () => {
 
     // Find enrichment call (removeIfExists=false, distinct from completeInteractiveLogin's call with true)
 
-    const enrichmentCall = (mockStateStore.set as any).mock.calls.find(
+    const enrichmentCall = mockStateStoreSetSpy.mock.calls.find(
       (call: any[]) => call[2] === false
     );
     expect(enrichmentCall).toBeDefined();
@@ -320,7 +328,7 @@ describe('onCallback Hook', () => {
 
     // Find enrichment call (removeIfExists=false)
 
-    const enrichmentCall = (mockStateStore.set as any).mock.calls.find(
+    const enrichmentCall = mockStateStoreSetSpy.mock.calls.find(
       (call: any[]) => call[2] === false
     );
     expect(enrichmentCall).toBeDefined();
@@ -352,7 +360,7 @@ describe('onCallback Hook', () => {
     // Verify internal field was preserved from captured state (set during completeInteractiveLogin)
 
     // stateStore.set is called twice: once by completeInteractiveLogin (via proxy), once by enrichment
-    const enrichmentCall = (mockStateStore.set as any).mock.calls.find(
+    const enrichmentCall = mockStateStoreSetSpy.mock.calls.find(
       (call: any[]) => call[2] === false // enrichment uses removeIfExists=false
     );
     expect(enrichmentCall).toBeDefined();
@@ -383,7 +391,7 @@ describe('onCallback Hook', () => {
 
     // Find the enrichment call (removeIfExists=false)
 
-    const enrichmentCall = (mockStateStore.set as any).mock.calls.find(
+    const enrichmentCall = mockStateStoreSetSpy.mock.calls.find(
       (call: any[]) => call[2] === false
     );
     expect(enrichmentCall).toBeDefined();

--- a/test/integration/concurrent-callbacks.test.ts
+++ b/test/integration/concurrent-callbacks.test.ts
@@ -1,239 +1,215 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
- * Integration test: concurrent OAuth callback handling.
+ * Integration test: concurrent OAuth callback session capture.
  *
- * Verifies that the stateStore.set() monkey-patching in callback.ts:
- * 1. Isolates captured state when identifiers differ (true isolation)
- * 2. Documents the known race condition when identifiers match (same cookie name)
- * 3. Restores original stateStore.set on error (finally{} block)
+ * Verifies that the WeakMap-based capture registry (captureRegistry.ts):
+ * 1. Isolates captured state per request via Hono Context object identity
+ * 2. Handles concurrent callbacks without cross-request data leakage
+ * 3. Handles error scenarios gracefully (no capture on failed login)
+ * 4. Is idempotent — double-install is a no-op
+ * 5. Cleans up captured state after retrieval
  *
- * The patch window is ~50ms. In serverless (1 request/isolate), no issue.
+ * This replaces the previous monkey-patch/restore pattern which was vulnerable to
+ * race conditions under concurrent callbacks (nested patch chain corruption).
  */
 import { StateData, StateStore } from '@auth0/auth0-server-js';
 import { describe, expect, it, vi } from 'vitest';
+import {
+  clearCapturedState,
+  getCapturedState,
+  installCaptureInterceptor,
+} from '../../src/session/captureRegistry';
 
-describe('Callback stateStore.set() Monkey-Patch', () => {
-  describe('Isolation: different identifiers', () => {
-    it('should only capture state for matching identifier', async () => {
-      const stateStore: StateStore<any> = {
-        get: vi.fn(),
-        set: vi.fn(),
-        delete: vi.fn(),
-      };
+function createMockStateStore(): StateStore<any> {
+  return {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  };
+}
 
-      let capturedStateData: StateData | null = null;
-      const targetIdentifier = 'appSession';
+function createMockContext(id: string): any {
+  // Each context is a unique object — WeakMap uses reference equality
+  return { __testId: id };
+}
 
-      const originalSet = stateStore.set;
-      stateStore.set = async function (id, data, removeIfExists, opts) {
-        if (id === targetIdentifier) {
-          capturedStateData = data as StateData;
-        }
-        return originalSet.call(this, id, data, removeIfExists, opts);
-      };
+function createStateData(sub: string): StateData {
+  return {
+    user: { sub },
+    idToken: `token_${sub}`,
+    tokenSets: [],
+    internal: { sid: `sid_${sub}`, createdAt: Math.floor(Date.now() / 1000) },
+  } as any;
+}
+
+describe('WeakMap Capture Registry — Concurrency Safety', () => {
+  describe('Per-request isolation', () => {
+    it('should capture state data keyed by unique context object', async () => {
+      const stateStore = createMockStateStore();
+      installCaptureInterceptor(stateStore, 'appSession');
+
+      const ctxA = createMockContext('request-A');
+      const ctxB = createMockContext('request-B');
+      const stateA = createStateData('user_A');
+      const stateB = createStateData('user_B');
+
+      // Simulate concurrent completeInteractiveLogin calls
+      await stateStore.set('appSession', stateA, true, ctxA);
+      await stateStore.set('appSession', stateB, true, ctxB);
+
+      // Each context retrieves ONLY its own captured state
+      expect(getCapturedState(ctxA)).toEqual(stateA);
+      expect(getCapturedState(ctxB)).toEqual(stateB);
+      expect(getCapturedState(ctxA)!.user.sub).toBe('user_A');
+      expect(getCapturedState(ctxB)!.user.sub).toBe('user_B');
+    });
+
+    it('should NOT cross-contaminate under interleaved async operations', async () => {
+      const stateStore = createMockStateStore();
+      installCaptureInterceptor(stateStore, 'appSession');
+
+      const contexts = Array.from({ length: 10 }, (_, i) => createMockContext(`req-${i}`));
+      const states = Array.from({ length: 10 }, (_, i) => createStateData(`user_${i}`));
+
+      // Simulate 10 concurrent callbacks in arbitrary order
+      const promises = contexts.map((ctx, i) =>
+        stateStore.set('appSession', states[i], true, ctx)
+      );
+      await Promise.all(promises);
+
+      // Each context retrieves only its own state — zero cross-contamination
+      contexts.forEach((ctx, i) => {
+        const captured = getCapturedState(ctx);
+        expect(captured).not.toBeNull();
+        expect(captured!.user.sub).toBe(`user_${i}`);
+      });
+    });
+
+    it('should not capture when identifier does not match', async () => {
+      const stateStore = createMockStateStore();
+      installCaptureInterceptor(stateStore, 'appSession');
+
+      const ctx = createMockContext('request-X');
+      const stateData = createStateData('user_X');
 
       // Call with different identifier — should NOT capture
-      const otherData: StateData = {
-        user: { sub: 'other_user' },
-        idToken: 'other_token',
-        tokenSets: [],
-        internal: { sid: 'other_sid', createdAt: 9999 },
-      } as any;
+      await stateStore.set('differentCookie', stateData, true, ctx);
 
-      await stateStore.set('differentCookieName', otherData, false, {} as any);
-      expect(capturedStateData).toBeNull();
-
-      // Call with matching identifier — should capture
-      const matchingData: StateData = {
-        user: { sub: 'target_user' },
-        idToken: 'target_token',
-        tokenSets: [],
-        internal: { sid: 'target_sid', createdAt: 1000 },
-      } as any;
-
-      await stateStore.set(targetIdentifier, matchingData, false, {} as any);
-      expect(capturedStateData).not.toBeNull();
-      expect(capturedStateData!.user.sub).toBe('target_user');
+      expect(getCapturedState(ctx)).toBeUndefined();
     });
 
-    it('should isolate captures when two concurrent patches use different identifiers', async () => {
-      const stateStore: StateStore<any> = {
-        get: vi.fn(),
-        set: vi.fn(),
-        delete: vi.fn(),
-      };
+    it('should not capture when opts is undefined', async () => {
+      const stateStore = createMockStateStore();
+      installCaptureInterceptor(stateStore, 'appSession');
 
-      let captured1: StateData | null = null;
-      let captured2: StateData | null = null;
-      const identifier1 = 'tenantA_session';
-      const identifier2 = 'tenantB_session';
+      const stateData = createStateData('user_no_ctx');
 
-      // Request 1 patches stateStore.set
-      const originalSet = stateStore.set;
-      stateStore.set = async function (id, data, removeIfExists, opts) {
-        if (id === identifier1) {
-          captured1 = data as StateData;
-        }
-        return originalSet.call(this, id, data, removeIfExists, opts);
-      };
+      // Call without opts (4th arg) — cannot key into WeakMap
+      await stateStore.set('appSession', stateData, true, undefined);
 
-      // Request 2 patches stateStore.set (chains through Request 1's patch)
-      const patchedByReq1 = stateStore.set;
-      stateStore.set = async function (id, data, removeIfExists, opts) {
-        if (id === identifier2) {
-          captured2 = data as StateData;
-        }
-        return patchedByReq1.call(this, id, data, removeIfExists, opts);
-      };
-
-      const stateData1: StateData = {
-        user: { sub: 'user_1' },
-        idToken: 'token_1',
-        tokenSets: [],
-        internal: { sid: 'sid_1', createdAt: 1000 },
-      } as any;
-
-      const stateData2: StateData = {
-        user: { sub: 'user_2' },
-        idToken: 'token_2',
-        tokenSets: [],
-        internal: { sid: 'sid_2', createdAt: 2000 },
-      } as any;
-
-      // Interleave: Request 2 writes first, then Request 1
-      await stateStore.set(identifier2, stateData2, false, {} as any);
-      await stateStore.set(identifier1, stateData1, false, {} as any);
-
-      // Each patch only captured its own identifier's data
-      expect(captured1!.user.sub).toBe('user_1');
-      expect(captured2!.user.sub).toBe('user_2');
+      // No crash, no capture — graceful handling
     });
   });
 
-  describe('Known limitation: same identifier (documents race condition)', () => {
-    it('should demonstrate cross-capture when both requests use same cookie name', async () => {
-      // This test documents the known limitation from Security Review F-001:
-      // When two concurrent requests use the same cookie name ('appSession'),
-      // overlapping patches can capture each other's state data.
-      //
-      // In practice this is safe because:
-      // 1. Each request's patch is restored in a finally{} block after ~50ms
-      // 2. Callback URLs are hit once per login flow (not under concurrent load)
-      // 3. The captured data is only used within the same request context
-      const stateStore: StateStore<any> = {
-        get: vi.fn(),
-        set: vi.fn(),
-        delete: vi.fn(),
-      };
+  describe('Cleanup', () => {
+    it('should clear captured state after retrieval', async () => {
+      const stateStore = createMockStateStore();
+      installCaptureInterceptor(stateStore, 'appSession');
 
-      let captured1: StateData | null = null;
-      let captured2: StateData | null = null;
-      const sameIdentifier = 'appSession';
+      const ctx = createMockContext('request-cleanup');
+      const stateData = createStateData('user_cleanup');
 
-      // Request 1 patches
-      const originalSet = stateStore.set;
-      stateStore.set = async function (id, data, removeIfExists, opts) {
-        if (id === sameIdentifier) {
-          captured1 = data as StateData;
-        }
-        return originalSet.call(this, id, data, removeIfExists, opts);
-      };
+      await stateStore.set('appSession', stateData, true, ctx);
 
-      // Request 2 patches (overwrites Request 1's patch — the race)
-      const patchedByReq1 = stateStore.set;
-      stateStore.set = async function (id, data, removeIfExists, opts) {
-        if (id === sameIdentifier) {
-          captured2 = data as StateData;
-        }
-        return patchedByReq1.call(this, id, data, removeIfExists, opts);
-      };
+      // First retrieval returns data
+      expect(getCapturedState(ctx)).toEqual(stateData);
 
-      const stateData1: StateData = {
-        user: { sub: 'user_1' },
-        idToken: 'token_1',
-        tokenSets: [],
-        internal: { sid: 'sid_1', createdAt: 1000 },
-      } as any;
+      // Clear
+      clearCapturedState(ctx);
 
-      const stateData2: StateData = {
-        user: { sub: 'user_2' },
-        idToken: 'token_2',
-        tokenSets: [],
-        internal: { sid: 'sid_2', createdAt: 2000 },
-      } as any;
-
-      // Both write to same identifier — both patches fire for each call
-      await stateStore.set(sameIdentifier, stateData1, false, {} as any);
-      await stateStore.set(sameIdentifier, stateData2, false, {} as any);
-
-      // captured1 was overwritten by stateData2 (same identifier matched both times)
-      // This is the documented race: last write to same identifier overwrites captured1
-      expect(captured1!.user.sub).toBe('user_2'); // Overwritten!
-      expect(captured2!.user.sub).toBe('user_2');
-    });
-
-    it('should simulate async interleaving where Request 2 patches before Request 1 restores', async () => {
-      // Simulates the actual race scenario:
-      // 1. Request 1 patches stateStore.set
-      // 2. Request 2 patches stateStore.set (before Request 1's finally{})
-      // 3. Request 1's finally{} restores "original" — but that's Request 2's patch!
-      // 4. Request 2's finally{} restores original — but original was already lost
-      //
-      // In real code, this requires two callback requests arriving within ~50ms of each other
-      // to the same Worker instance. Negligible in practice (OAuth callbacks are not concurrent).
-      const stateStore: StateStore<any> = {
-        get: vi.fn(),
-        set: vi.fn(),
-        delete: vi.fn(),
-      };
-
-      const trueOriginal = stateStore.set;
-
-      // Request 1 starts — captures "original"
-      const req1Original = stateStore.set;
-      stateStore.set = vi.fn() as any; // Request 1's patch
-
-      // Request 2 starts BEFORE Request 1 finishes — captures Request 1's patch as "original"
-      const req2Original = stateStore.set; // This is Request 1's patch, not true original!
-      stateStore.set = vi.fn() as any; // Request 2's patch
-
-      // Request 1 finishes — restores what it captured (Request 1's true original? No — it was overwritten)
-      stateStore.set = req1Original; // Restores true original (correct in this sequence)
-
-      // Request 2 finishes — restores what it captured (Request 1's patch!)
-      stateStore.set = req2Original; // Restores Request 1's patch — NOT true original!
-
-      // After both complete: stateStore.set is Request 1's patch, not the true original
-      // This demonstrates the race — but only possible if two callbacks overlap
-      expect(stateStore.set).not.toBe(trueOriginal);
-      // In real code, the finally{} block mitigates this by executing immediately
-      // after completeInteractiveLogin (~50ms), making the window extremely small.
+      // Second retrieval returns undefined
+      expect(getCapturedState(ctx)).toBeUndefined();
     });
   });
 
-  describe('Error recovery: finally{} block', () => {
-    it('should restore original stateStore.set even if completeInteractiveLogin throws', () => {
+  describe('Idempotent installation', () => {
+    it('should be a no-op when called twice on same stateStore', async () => {
+      const stateStore = createMockStateStore();
+
+      installCaptureInterceptor(stateStore, 'appSession');
+      const firstPatch = stateStore.set;
+
+      installCaptureInterceptor(stateStore, 'appSession');
+      const secondPatch = stateStore.set;
+
+      // Same function reference — second install was a no-op
+      expect(firstPatch).toBe(secondPatch);
+    });
+
+    it('should still function correctly after double-install attempt', async () => {
+      const stateStore = createMockStateStore();
+      installCaptureInterceptor(stateStore, 'appSession');
+      installCaptureInterceptor(stateStore, 'appSession');
+
+      const ctx = createMockContext('double-install');
+      const stateData = createStateData('user_double');
+
+      await stateStore.set('appSession', stateData, true, ctx);
+      expect(getCapturedState(ctx)!.user.sub).toBe('user_double');
+    });
+  });
+
+  describe('Error scenarios', () => {
+    it('should not have captured state when login fails before set is called', () => {
+      const stateStore = createMockStateStore();
+      installCaptureInterceptor(stateStore, 'appSession');
+
+      const ctx = createMockContext('failed-request');
+
+      // Simulate completeInteractiveLogin throwing before stateStore.set
+      // (e.g. MissingTransactionError)
+      // stateStore.set is never called for this context
+
+      expect(getCapturedState(ctx)).toBeUndefined();
+    });
+
+    it('should delegate to original set and propagate errors', async () => {
+      const setError = new Error('store write failed');
+      const stateStore: StateStore<any> = {
+        get: vi.fn(),
+        set: vi.fn().mockRejectedValue(setError),
+        delete: vi.fn(),
+      };
+      installCaptureInterceptor(stateStore, 'appSession');
+
+      const ctx = createMockContext('error-request');
+      const stateData = createStateData('user_error');
+
+      // Should propagate original error
+      await expect(stateStore.set('appSession', stateData, true, ctx)).rejects.toThrow('store write failed');
+
+      // State is still captured (capture happens before delegation)
+      expect(getCapturedState(ctx)).toEqual(stateData);
+    });
+  });
+
+  describe('Delegates to original set correctly', () => {
+    it('should call original set with all arguments', async () => {
       const originalSetFn = vi.fn();
-      const stateStore = {
+      const stateStore: StateStore<any> = {
         get: vi.fn(),
-        set: originalSetFn as any,
+        set: originalSetFn,
         delete: vi.fn(),
       };
+      installCaptureInterceptor(stateStore, 'appSession');
 
-      // Simulate patch + error + restore (from callback.ts pattern)
-      const originalSet = stateStore.set;
-      stateStore.set = vi.fn() as any; // Patch
+      const ctx = createMockContext('delegation-test');
+      const stateData = createStateData('user_delegate');
 
-      try {
-        throw new Error('login_required');
-      } catch {
-        // Error handled by caller (mapServerError in real code)
-      } finally {
-        // Always restore (mirrors callback.ts:88)
-        stateStore.set = originalSet;
-      }
+      await stateStore.set('appSession', stateData, true, ctx);
 
-      expect(stateStore.set).toBe(originalSetFn);
+      // Original function was called with exact same arguments
+      expect(originalSetFn).toHaveBeenCalledWith('appSession', stateData, true, ctx);
     });
   });
 });


### PR DESCRIPTION
## Summary 

Fixes a session confusion vulnerability where concurrent callback requests in Node.js could cause cross-user session data leakage through the `onCallback` hook enrichment path. 
Exploitation requires concurrent OAuth completions + an `onCallback` hook that modifies session data. 


## Details

- Replace per-request monkey-patch/restore of `stateStore.set` with a one-time WeakMap-based capture interceptor installed at init 
- Eliminate race condition where concurrent OAuth callbacks could leak session data across requests when `onCallback` hook enriches session
- WeakMap keyed by Hono Context object provides isolation via reference uniqueness — no patch stacking, no restore chain corruption


## Test plan

- [x] Existing 327 tests pass (no regressions)
- [x] New concurrency isolation tests: 10 cases covering parallel captures, cleanup, double-install idempotency, error
propagation 
- [x] Hook enrichment tests updated to work with interceptor pattern
- [ ] Manual: concurrent callback simulation with `onCallback` hook under load