### PR TITLE
fix: Secuity hardening

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -82,6 +82,7 @@ export function auth0(initConfig: PartialConfig = {}): MiddlewareHandler {
     async (c, next: Next): Promise<Response | void> => {
       try {
         // === LAZY SINGLETON INITIALIZATION ===
+        // Not a race — JS event loop is single-threaded; assignment is atomic.
         if (!initPromise) {
           initPromise = Promise.resolve().then(() => {
             // Get runtime environment (no process.env!)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -33,6 +33,8 @@ import { assignFromEnv } from './envConfig.js';
  * No customer-facing key needed.
  */
 const parsedConfigByRef = new WeakMap<object, Configuration>();
+// Tier-2 only activates for ensureClient() configs which never contain
+// functions (env-only). No collision between function-bearing and function-free configs.
 const parsedConfigByValue = new Map<string, Configuration>();
 
 export const parseConfiguration = (config: InitConfiguration): Configuration => {

--- a/src/middleware/callback.ts
+++ b/src/middleware/callback.ts
@@ -129,9 +129,11 @@ export const callback = (params: CallbackParams = {}) => {
         return next();
       }
 
+      // appState is encrypted in transaction cookie (server-js),
+      // but validate returnTo anyway to eliminate open redirect class entirely.
       const finalURL =
         (params.redirectAfterLogin ? toSafeRedirect(params.redirectAfterLogin, baseURL) : undefined) ??
-        appState?.returnTo ??
+        (appState?.returnTo ? toSafeRedirect(appState.returnTo, baseURL) : undefined) ??
         baseURL;
 
       return c.redirect(finalURL);

--- a/src/middleware/login.ts
+++ b/src/middleware/login.ts
@@ -125,6 +125,11 @@ export const login = (params: LoginParams = {}) => {
           if (value) {
             // Normalize to string: if array, use first value (standard behavior)
             const normalizedValue = Array.isArray(value) ? value[0] : value;
+            // Reject values containing CR/LF/NUL to prevent HTTP Response Splitting.
+            // Ref: https://owasp.org/www-community/attacks/HTTP_Response_Splitting
+            if (/[\r\n\0]/.test(normalizedValue)) {
+              continue;
+            }
             paramsFromQuery[param] = normalizedValue;
           }
         }

--- a/src/middleware/logout.ts
+++ b/src/middleware/logout.ts
@@ -1,10 +1,12 @@
-import { getClient, ensureClient } from '@/config/index.js';
+import { ensureClient, getClient } from '@/config/index.js';
+import { mapServerError } from '@/errors/errorMap.js';
+import { invalidateSessionCache } from '@/helpers/sessionCache.js';
 import { OIDCEnv } from '@/lib/honoEnv.js';
 import { toSafeRedirect } from '@/utils/util.js';
-import { mapServerError } from '@/errors/errorMap.js';
+import { MiddlewareHandler } from 'hono';
+import { deleteCookie } from 'hono/cookie';
 import { createMiddleware } from 'hono/factory';
 import { deleteSilentLoginCookie } from './silentLogin.js';
-import { MiddlewareHandler } from 'hono';
 
 export type LogoutParams = {
   /**
@@ -35,6 +37,12 @@ export const logout = (params: LogoutParams = {}) => {
       }
 
       const logoutUrl = await client.logout({ returnTo }, c);
+
+      // Invalidate session cache — prevent stale reads in same request lifecycle
+      invalidateSessionCache(c);
+
+      // Delete stale transaction cookie
+      deleteCookie(c, '__a0_tx', { path: '/', sameSite: 'Lax', httpOnly: true });
 
       // Delete silent login skip cookie directly — do NOT use resumeSilentLogin()(c, next).
       // See callback.ts for full explanation of the next() poisoning bug.

--- a/src/session/HonoCookieHandler.ts
+++ b/src/session/HonoCookieHandler.ts
@@ -28,17 +28,6 @@ import { CookieOptions } from 'hono/utils/cookie';
  *   - Ref: https://github.com/webpack/webpack/pull/18076
  *   - Ref: https://developers.cloudflare.com/workers/runtime-apis/nodejs/
  *
- * WHY NOT A POLYFILL:
- * A try/finally polyfill breaks under concurrent requests (Workers share isolate;
- * Request A overwrites Request B's stored context). Real ALS uses V8 async context
- * tracking across promise chains. A correct polyfill (zone.js) is 10KB+. Since ALS
- * is defensive-only, a clear error on the rare edge case beats a subtly wrong polyfill.
- *
- * PRIOR ART:
- * No major library uses this exact pattern. Hono avoids ALS entirely (explicit context
- * passing). nextjs-auth0 uses @edge-runtime/cookies without ALS. OpenTelemetry uses
- * pluggable managers with static import (fails on Workers). Our case is unique: we
- * follow Hono's explicit pattern (storeOptions) but retain ALS as forward-compat guard.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let AsyncLocalStorageImpl: (new () => any) | null = null;
@@ -58,11 +47,8 @@ function capitalize<T extends string>(s: T): Capitalize<T> {
 export class HonoCookieHandler implements CookieHandler<Context> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private static localStore: any = AsyncLocalStorageImpl ? new AsyncLocalStorageImpl() : null;
-  // Cache cookie options per name for deletion (Chrome scheme-bound cookies require matching attrs).
-  // This is a singleton instance — persists across requests. Last-write-wins per cookie name.
-  // Safe because each cookie name (__a0_tx, appSession, etc.) always uses the same options
-  // across its lifecycle. If a future feature uses dynamic options per-cookie-name, this
-  // would need to be request-scoped.
+  // Singleton cache is safe — cookie names are static per lifecycle.
+  // Multi-tenant deployments use ensureClient() which creates separate handler instances.
   private cookieOptionsCache = new Map<string, CookieOptions>();
 
   static setContext<R>(context: Context, callback: () => R): R {
@@ -127,6 +113,9 @@ export class HonoCookieHandler implements CookieHandler<Context> {
     return result;
   }
 
+  // httpOnly enforcement is handled by server-js — all store implementations
+  // always pass httpOnly:true in cookie options.
+  // Ref: https://github.com/auth0/auth0-auth-js/blob/e1af6b311d83/packages/auth0-server-js/src/store/stateless-state-store.ts#L82
   setCookie(name: string, value: string, options?: CookieSerializeOptions, storeOptions?: Context): string {
     const cookieOptions: CookieOptions | undefined = options
       ? {
@@ -156,24 +145,34 @@ export class HonoCookieHandler implements CookieHandler<Context> {
     }
   }
 
-  deleteCookie(name: string, storeOptions?: Context): void {
+  deleteCookie(name: string, storeOptions?: Context, options?: CookieSerializeOptions): void {
     const ctx = this.getContext(storeOptions);
-    // IMPORTANT: Replay stored attributes on deletion.
     // Chrome 118+ uses scheme-bound cookies — deletion must match creation attributes
     // (sameSite, secure, path, domain) exactly, otherwise cookie persists.
-    // Same issue was hit in nextjs-auth0.
-    const storedOptions = this.cookieOptionsCache.get(name);
-    const cookieOptions: CookieOptions = {
-      path: storedOptions?.path ?? '/',
-      maxAge: 0,
-      ...(storedOptions
-        ? {
-            sameSite: storedOptions.sameSite,
-            secure: storedOptions.secure,
-            domain: storedOptions.domain,
-          }
-        : {}),
-    };
+    // Priority: explicit options from server-js > cached options > minimal defaults.
+    const cookieOptions: CookieOptions = options
+      ? {
+          path: options.path ?? '/',
+          maxAge: 0,
+          sameSite: options.sameSite ? capitalize(options.sameSite) : undefined,
+          secure: options.secure,
+          domain: options.domain,
+          httpOnly: options.httpOnly,
+        }
+      : (() => {
+          const storedOptions = this.cookieOptionsCache.get(name);
+          return {
+            path: storedOptions?.path ?? '/',
+            maxAge: 0,
+            ...(storedOptions
+              ? {
+                  sameSite: storedOptions.sameSite,
+                  secure: storedOptions.secure,
+                  domain: storedOptions.domain,
+                }
+              : {}),
+          };
+        })();
     setCookie(ctx, name, '', cookieOptions);
   }
 }

--- a/src/session/captureRegistry.ts
+++ b/src/session/captureRegistry.ts
@@ -25,6 +25,8 @@ import { Context } from 'hono';
  * @internal
  */
 const captureRegistry = new WeakMap<Context, StateData>();
+/** Tracks contexts that have already captured — prevents re-entry overwrite after clearCapturedState. */
+const capturedOnce = new WeakSet<Context>();
 
 /**
  * Symbol guard to prevent double-installation of the interceptor.
@@ -57,10 +59,13 @@ export function installCaptureInterceptor(stateStore: StateStore<Context>, ident
     removeIfExists?: boolean,
     opts?: Context
   ): Promise<void> {
-    if (id === identifier && opts) {
+    await originalSet(id, data, removeIfExists, opts);
+    // Only capture FIRST write per request — prevents onCallback hook re-entry
+    // from overwriting original OAuth session with enriched data.
+    if (id === identifier && opts && !capturedOnce.has(opts)) {
       captureRegistry.set(opts, data);
+      capturedOnce.add(opts);
     }
-    return originalSet(id, data, removeIfExists, opts);
   };
 
   (stateStore as GuardedStore)[INTERCEPTOR_INSTALLED] = true;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -485,6 +485,106 @@ describe('Environment Configuration', () => {
     });
   });
 
+  // Verify two-tier cache doesn't allow cross-contamination
+  describe('Config cache Tier-1/Tier-2 isolation (VULN-8)', () => {
+    it('should use Tier-1 (ref equality) for configs with functions — no Tier-2 collision', () => {
+      const configWithFn: InitConfiguration = {
+        domain: 'auth.example.com',
+        baseURL: 'https://app.example.com',
+        clientID: 'client-a',
+        clientSecret: 'test-secret',
+        session: { secret: 'test-secret-longer-than-32-chars' },
+        debug: () => {}, // Function field → Tier-1 only
+      };
+
+      const result1 = parseConfiguration(configWithFn);
+      const result2 = parseConfiguration(configWithFn);
+
+      // Same reference → Tier-1 cache hit
+      expect(result1).toBe(result2);
+      expect(result1.clientID).toBe('client-a');
+    });
+
+    it('should use Tier-2 (JSON key) for env-only configs without functions', () => {
+      // Simulates ensureClient() creating new objects with same values per-request
+      const makeEnvConfig = (): InitConfiguration => ({
+        domain: 'auth.example.com',
+        baseURL: 'https://app.example.com',
+        clientID: 'client-b',
+        clientSecret: 'test-secret',
+        session: { secret: 'test-secret-longer-than-32-chars' },
+      });
+
+      const result1 = parseConfiguration(makeEnvConfig());
+      const result2 = parseConfiguration(makeEnvConfig());
+
+      // Different references but same values → Tier-2 hit
+      expect(result1).toBe(result2);
+      expect(result1.clientID).toBe('client-b');
+    });
+
+    it('should NOT collide between function-bearing and function-free configs with same serializable fields', () => {
+      // Key insight: JSON.stringify drops functions. If Tier-2 cached the function-bearing
+      // config (wrong), then the function-free lookup would return a result with a custom
+      // debug function. If correctly routed to Tier-1, the function stays isolated.
+
+      // Config WITH custom debug function (should route to Tier-1 only)
+      const configWithFn: InitConfiguration = {
+        domain: 'auth.example.com',
+        baseURL: 'https://app.example.com',
+        clientID: 'client-c',
+        clientSecret: 'test-secret',
+        session: { secret: 'test-secret-longer-than-32-chars' },
+        debug: () => { /* custom logger */ },
+      };
+
+      // Config WITHOUT function (should route to Tier-2) — same serializable fields
+      const configWithoutFn: InitConfiguration = {
+        domain: 'auth.example.com',
+        baseURL: 'https://app.example.com',
+        clientID: 'client-c',
+        clientSecret: 'test-secret',
+        session: { secret: 'test-secret-longer-than-32-chars' },
+      };
+
+      const resultWithFn = parseConfiguration(configWithFn);
+      const resultWithoutFn = parseConfiguration(configWithoutFn);
+
+      // Critical assertion: function-bearing config retains custom debug
+      expect(resultWithFn.debug).toBe(configWithFn.debug);
+
+      // Function-free config gets default debug (not the custom one from Tier-1)
+      // If there WAS a collision, resultWithoutFn.debug would be configWithFn.debug
+      expect(resultWithoutFn.debug).not.toBe(configWithFn.debug);
+    });
+
+    it('should NOT collide between two different env-only configs in Tier-2', () => {
+      const configA: InitConfiguration = {
+        domain: 'tenant-a.auth0.com',
+        baseURL: 'https://app-a.example.com',
+        clientID: 'client-a',
+        clientSecret: 'secret-a-longer-than-32-chars-xx',
+        session: { secret: 'secret-a-longer-than-32-chars-xx' },
+      };
+
+      const configB: InitConfiguration = {
+        domain: 'tenant-b.auth0.com',
+        baseURL: 'https://app-b.example.com',
+        clientID: 'client-b',
+        clientSecret: 'secret-b-longer-than-32-chars-xx',
+        session: { secret: 'secret-b-longer-than-32-chars-xx' },
+      };
+
+      const resultA = parseConfiguration(configA);
+      const resultB = parseConfiguration(configB);
+
+      // Different JSON keys → different cache entries → no collision
+      expect(resultA.domain).toBe('tenant-a.auth0.com');
+      expect(resultB.domain).toBe('tenant-b.auth0.com');
+      expect(resultA).not.toBe(resultB);
+    });
+  });
+
   describe('No process.env usage verification (REQ-BUG-1)', () => {
     it('should resolve config entirely from env(c) parameter without accessing process.env', () => {
       const config: InitConfiguration = {

--- a/test/helpers/getAccessToken.test.ts
+++ b/test/helpers/getAccessToken.test.ts
@@ -111,33 +111,27 @@ describe('getAccessToken(c)', () => {
       expiresAt: Date.now() + 3600000,
     } as any;
 
-    // Setup: all three calls see the same refresh cache key
-    const refreshCache = new Map();
-    mockContext.get
-      .mockReturnValueOnce(undefined) // First call: REFRESH_CACHE_KEY miss
-      .mockReturnValueOnce(refreshCache) // Second call: REFRESH_CACHE_KEY hit
-      .mockReturnValueOnce(refreshCache) // Third call: REFRESH_CACHE_KEY hit
-      .mockReturnValueOnce(undefined); // Invalidate SESSION_CACHE_KEY after first call
+    // Simulate slow token refresh — forces concurrent calls to share same promise
+    mockClient.getAccessToken.mockImplementation(
+      () => new Promise<TokenSet>((resolve) => setTimeout(() => resolve(mockTokenSet), 50))
+    );
 
-    // Store the promise in the cache manually to simulate concurrent behavior
-    const cacheKey = '__default__';
-    const tokenPromise = Promise.resolve(mockTokenSet);
-    refreshCache.set(cacheKey, tokenPromise);
-    mockClient.getAccessToken.mockResolvedValueOnce(mockTokenSet);
+    // Simulate real context storage: get/set share the same backing store
+    const contextStore = new Map<string, any>();
+    mockContext.get.mockImplementation((key: string) => contextStore.get(key));
+    mockContext.set.mockImplementation((key: string, value: any) => contextStore.set(key, value));
 
-    // Call 1: Creates promise in cache
-    const result1 = getAccessToken(mockContext);
-
-    // Call 2 & 3: Would await same promise (we'll just verify they get same result)
-    const result2 = getAccessToken(mockContext);
-    const result3 = getAccessToken(mockContext);
-
-    const [res1, res2, res3] = await Promise.all([result1, result2, result3]);
+    // Fire 3 concurrent calls — first creates Map + promise, second/third reuse it
+    const [res1, res2, res3] = await Promise.all([
+      getAccessToken(mockContext),
+      getAccessToken(mockContext),
+      getAccessToken(mockContext),
+    ]);
 
     expect(res1).toEqual(mockTokenSet);
     expect(res2).toEqual(mockTokenSet);
     expect(res3).toEqual(mockTokenSet);
-    // Verify client called only once
+    // Critical: client.getAccessToken called ONCE despite 3 concurrent calls
     expect(mockClient.getAccessToken).toHaveBeenCalledTimes(1);
   });
 
@@ -228,11 +222,25 @@ describe('getAccessToken(c)', () => {
 
   // REQ-B5: Single cache key — audience fixed at client init
   describe('cache key', () => {
-    it('should use fixed cache key for all calls (audience from client config)', () => {
-      // server-js determines audience from authorizationParams.audience at init
-      // No per-call audience override — single cache key suffices
-      const cacheKey = '__default__';
-      expect(cacheKey).toBe('__default__');
+    it('should store token promise under single fixed key regardless of call count', async () => {
+      const mockTokenSet: TokenSet = {
+        accessToken: 'cached_token',
+        expiresAt: Date.now() + 3600000,
+      } as any;
+
+      mockContext.get.mockReturnValueOnce(undefined); // REFRESH_CACHE_KEY miss
+      mockClient.getAccessToken.mockResolvedValueOnce(mockTokenSet);
+      mockContext.get.mockReturnValueOnce(undefined); // SESSION_CACHE_KEY miss
+
+      await getAccessToken(mockContext);
+
+      // Verify the cache was set with a Map containing exactly one key
+      const setCalls = mockContext.set.mock.calls.filter((call: any[]) => call[0] === REFRESH_CACHE_KEY);
+      expect(setCalls.length).toBeGreaterThan(0);
+      const storedMap = setCalls[0][1] as Map<string, any>;
+      expect(storedMap).toBeInstanceOf(Map);
+      expect(storedMap.size).toBe(1);
+      expect(storedMap.has('__default__')).toBe(true);
     });
   });
 

--- a/test/integration/concurrent-callbacks.test.ts
+++ b/test/integration/concurrent-callbacks.test.ts
@@ -65,13 +65,21 @@ describe('WeakMap Capture Registry — Concurrency Safety', () => {
     });
 
     it('should NOT cross-contaminate under interleaved async operations', async () => {
-      const stateStore = createMockStateStore();
+      // Use a real async stateStore.set with random delays to force genuine interleaving
+      const originalSetFn = vi.fn().mockImplementation(
+        () => new Promise<void>((resolve) => setTimeout(resolve, Math.random() * 10))
+      );
+      const stateStore: StateStore<any> = {
+        get: vi.fn(),
+        set: originalSetFn,
+        delete: vi.fn(),
+      };
       installCaptureInterceptor(stateStore, 'appSession');
 
       const contexts = Array.from({ length: 10 }, (_, i) => createMockContext(`req-${i}`));
       const states = Array.from({ length: 10 }, (_, i) => createStateData(`user_${i}`));
 
-      // Simulate 10 concurrent callbacks in arbitrary order
+      // Fire 10 concurrent callbacks — random delays force real interleaving
       const promises = contexts.map((ctx, i) =>
         stateStore.set('appSession', states[i], true, ctx)
       );
@@ -83,6 +91,9 @@ describe('WeakMap Capture Registry — Concurrency Safety', () => {
         expect(captured).not.toBeNull();
         expect(captured!.user.sub).toBe(`user_${i}`);
       });
+
+      // All 10 original set calls completed
+      expect(originalSetFn).toHaveBeenCalledTimes(10);
     });
 
     it('should not capture when identifier does not match', async () => {
@@ -188,8 +199,8 @@ describe('WeakMap Capture Registry — Concurrency Safety', () => {
       // Should propagate original error
       await expect(stateStore.set('appSession', stateData, true, ctx)).rejects.toThrow('store write failed');
 
-      // State is still captured (capture happens before delegation)
-      expect(getCapturedState(ctx)).toEqual(stateData);
+      // State is NOT captured when originalSet throws — capture executes after delegation
+      expect(getCapturedState(ctx)).toBeUndefined();
     });
   });
 

--- a/test/middleware/logout.test.ts
+++ b/test/middleware/logout.test.ts
@@ -20,6 +20,14 @@ vi.mock('../../src/middleware/silentLogin', () => ({
   deleteSilentLoginCookie: vi.fn(),
 }));
 
+vi.mock('../../src/helpers/sessionCache', () => ({
+  invalidateSessionCache: vi.fn(),
+}));
+
+vi.mock('hono/cookie', () => ({
+  deleteCookie: vi.fn(),
+}));
+
 describe('logout middleware', () => {
   let mockContext: Context;
   let mockOidcSession: any;

--- a/test/session/cookieHandler.test.ts
+++ b/test/session/cookieHandler.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Context } from 'hono';
-import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
-import { HonoCookieHandler } from '../../src/session/HonoCookieHandler';
 import { getCookie, setCookie } from 'hono/cookie';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HonoCookieHandler } from '../../src/session/HonoCookieHandler';
 
 // Mock hono/cookie
 vi.mock('hono/cookie', () => ({
@@ -145,7 +145,7 @@ describe('HonoCookieHandler', () => {
     });
 
     // REQ-A1: Handle malformed %-encoding in cookie values (crash prevention)
-    it('should handle malformed %-encoding in cookie values without crashing', () => {
+    it('should return raw value for malformed %-encoding (not crash)', () => {
       mockContext.req.header = vi.fn((headerName: string) => {
         if (headerName === 'Cookie') {
           return 'malformed=%XX%ZZ; valid=ok';
@@ -153,12 +153,11 @@ describe('HonoCookieHandler', () => {
         return undefined;
       });
 
-      // Should not crash; should return raw value or empty
       const result = cookieHandler.getCookies(mockContext as any);
 
-      expect(result).toBeDefined();
-      expect(typeof result).toBe('object');
-      // May contain raw value or skip the malformed cookie
+      // Malformed cookie returns raw undecoded value (fallback behavior)
+      expect(result.malformed).toBe('%XX%ZZ');
+      // Valid cookies still decode correctly
       expect(result.valid).toBe('ok');
     });
 
@@ -349,7 +348,93 @@ describe('HonoCookieHandler', () => {
     });
   });
 
-  // REQ-C1: Throw Auth0Error (not generic Error) when ALS unavailable
+  // AUDIT(VULN-2): Verify httpOnly survives full cookie lifecycle (set → delete).
+  // The claim: server-js always passes httpOnly:true. We can't test upstream here,
+  // but we CAN prove that if httpOnly is passed (which it always is), our handler
+  // never drops it — neither in setCookie, cached options, nor deleteCookie.
+  describe('httpOnly preservation through full cookie lifecycle', () => {
+    it('should retain httpOnly through set → delete cycle (explicit options path)', () => {
+      const ctx = mockContext as any;
+
+      // Step 1: setCookie with httpOnly (simulates server-js StatelessStateStore)
+      cookieHandler.setCookie('appSession.0', 'encrypted', {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: true,
+        maxAge: 86400,
+      }, ctx);
+
+      vi.mocked(setCookie).mockClear();
+
+      // Step 2: deleteCookie with explicit options (simulates StatelessStateStore.delete())
+      cookieHandler.deleteCookie('appSession.0', ctx, {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: true,
+      });
+
+      // Verify deletion includes httpOnly — Chrome 118+ requires matching attrs
+      expect(setCookie).toHaveBeenCalledWith(
+        ctx,
+        'appSession.0',
+        '',
+        expect.objectContaining({
+          httpOnly: true,
+          sameSite: 'Lax',
+          secure: true,
+          path: '/',
+          maxAge: 0,
+        })
+      );
+    });
+
+    it('should retain cookie attributes through set → cache → delete cycle (cached path)', () => {
+      const ctx = mockContext as any;
+
+      // Step 1: setCookie populates cookieOptionsCache
+      cookieHandler.setCookie('__a0_tx', 'encrypted_tx', {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 3600,
+      }, ctx);
+
+      vi.mocked(setCookie).mockClear();
+
+      // Step 2: deleteCookie WITHOUT explicit options (CookieTransactionStore.delete() path)
+      // Must fall back to cached options from step 1
+      cookieHandler.deleteCookie('__a0_tx', ctx);
+
+      // Verify deletion uses cached sameSite (proves cache works for deletion)
+      expect(setCookie).toHaveBeenCalledWith(
+        ctx,
+        '__a0_tx',
+        '',
+        expect.objectContaining({
+          sameSite: 'Lax',
+          path: '/',
+          maxAge: 0,
+        })
+      );
+    });
+
+    it('should NOT inject httpOnly if upstream never sent it', () => {
+      const ctx = mockContext as any;
+
+      // Options without httpOnly — handler must not fabricate it
+      cookieHandler.deleteCookie('nonAuthCookie', ctx, {
+        path: '/',
+        sameSite: 'lax',
+      });
+
+      const callArgs = vi.mocked(setCookie).mock.calls[0]?.[3] as any;
+      expect(callArgs.httpOnly).toBeUndefined();
+    });
+  });
+
+  // Throw Auth0Error (not generic Error) when ALS unavailable
   describe('error handling when ALS context unavailable', () => {
     it('should throw Auth0Error (not generic Error) when no context available', () => {
       // When called without context and ALS unavailable


### PR DESCRIPTION
## Summary

Fixes some found issues from a pre-release security audit. 

-  `deleteCookie` signature mismatch with server-js — session cookie chunks persist on Chrome 118+ due to missing sameSite/secure/domain attrs on deletion.
-  Open redirect via unvalidated `appState.returnTo` in callback — now passed through `toSafeRedirect()`. 
-  CRLF/NUL injection in forwarded auth params — silently blocked with OWASP-referenced regex. 
-  Capture interceptor re-entry — `onCallback` hook could overwrite original OAuth session in WeakMap. Fixed with WeakSet first-write guard. 
-  Session cache stale after logout — `invalidateSessionCache(c)` added.
-  Stale `__a0_tx` transaction cookie (~4KB) persists after abandoned login flows — explicitly deleted on logout. 

Also adds inline comments on 4 rejected findings to prevent future re-flagging, and fixes 4 non-discriminating tests
 that were passing without proving their claims.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test` — 339/339 pass
- [x] `pnpm lint` — clean 
- [ ] Manual: login → callback → verify session cookie deletion on logout (Chrome DevTools) 
- [ ] Manual: inject external URL in appState.returnTo → verify redirect to baseURL