### PR TITLE
fix: change default value of idpLogout to true in jsdocs

### DIFF
--- a/src/config/Configuration.ts
+++ b/src/config/Configuration.ts
@@ -40,7 +40,7 @@ export interface Configuration {
 
   /**
    * Whether to use the IDP's logout endpoint.
-   * @default false
+   * @default true
    */
   idpLogout: boolean;
 


### PR DESCRIPTION
### Description

idpLogout is default false in v2.

### References

https://github.com/auth0/auth0-hono/blob/main/src/config/Schema.ts#L63


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
