### PR TITLE
fix: callback redirect_uri behind reverse proxies (#13)

### DIFF
--- a/src/middleware/callback.ts
+++ b/src/middleware/callback.ts
@@ -5,7 +5,7 @@ import { mapServerError } from '@/errors/errorMap.js';
 import { STATE_STORE_KEY } from '@/lib/constants.js';
 import { OIDCEnv } from '@/lib/honoEnv.js';
 import { clearCapturedState, getCapturedState } from '@/session/captureRegistry.js';
-import { createRouteUrl, toSafeRedirect } from '@/utils/util.js';
+import { createCallbackUrl, toSafeRedirect } from '@/utils/util.js';
 import { SessionData, StateData, StateStore } from '@auth0/auth0-server-js';
 import { Context, MiddlewareHandler, Next } from 'hono';
 import { createMiddleware } from 'hono/factory';
@@ -68,8 +68,10 @@ export const callback = (params: CallbackParams = {}) => {
       const { stateStore, identifier } = getStateStoreContext(c, configuration);
 
       // Complete the login flow
+      // Use createCallbackUrl to ensure baseURL's origin (protocol+host+port) is used,
+      // not the request URL's protocol/host which may be wrong behind a reverse proxy
       const { appState } = await client.completeInteractiveLogin<{ returnTo: string } | undefined>(
-        createRouteUrl(c.req.url, baseURL),
+        createCallbackUrl(c.req.url, baseURL),
         c
       );
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -29,6 +29,28 @@ export function createRouteUrl(url: string, base: string) {
 }
 
 /**
+ * Builds a callback URL using the baseURL's origin (protocol + host) combined with
+ * the request's pathname and search. This ensures reverse proxies that strip TLS
+ * don't cause redirect_uri mismatches.
+ *
+ * When behind a reverse proxy (e.g., AWS ALB), the incoming request URL may have
+ * the wrong protocol (http instead of https) or host. This helper extracts the
+ * pathname+search from the request and combines them with the configured baseURL's
+ * origin, ensuring the callback URL matches the redirect_uri sent to Auth0.
+ *
+ * @param requestUrl The request URL as seen by Hono (may have wrong protocol/host from proxy)
+ * @param baseURL The configured base URL (has correct protocol/host/port)
+ * @returns A URL whose origin comes from baseURL and pathname+search from the request
+ */
+export function createCallbackUrl(requestUrl: string, baseURL: string): URL {
+  const baseUrlObj = new URL(baseURL);
+  const requestUrlObj = new URL(requestUrl);
+
+  // Use baseURL's origin (protocol + host + port) with request's pathname + search
+  return new URL(`${baseUrlObj.origin}${requestUrlObj.pathname}${requestUrlObj.search}`);
+}
+
+/**
  * Function to ensure a redirect URL is safe to use, as in, it has the same origin as the safeBaseUrl.
  * @param dangerousRedirect The redirect URL to check.
  * @param safeBaseUrl The base URL to check against.

--- a/test/flows/hooks.spec.ts
+++ b/test/flows/hooks.spec.ts
@@ -16,6 +16,7 @@ vi.mock('../../src/config/index', () => ({
 
 vi.mock('../../src/utils/util', () => ({
   createRouteUrl: vi.fn((url) => url),
+  createCallbackUrl: vi.fn((url) => url),
   toSafeRedirect: vi.fn((url) => url),
 }));
 

--- a/test/middleware/callback.test.ts
+++ b/test/middleware/callback.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { getClient } from '../../src/config';
 import { callback } from '../../src/middleware/callback';
 import { deleteSilentLoginCookie } from '../../src/middleware/silentLogin';
-import { createRouteUrl } from '../../src/utils/util';
+import { createCallbackUrl } from '../../src/utils/util';
 
 // Mock dependencies
 vi.mock('../../src/config', () => ({
@@ -12,7 +12,7 @@ vi.mock('../../src/config', () => ({
 }));
 
 vi.mock('../../src/utils/util', () => ({
-  createRouteUrl: vi.fn(),
+  createCallbackUrl: vi.fn(),
   toSafeRedirect: vi.fn((url) => url), // Mock toSafeRedirect to return the input
 }));
 
@@ -73,8 +73,8 @@ describe('callback middleware', () => {
       configuration: mockConfiguration,
     });
 
-    // Setup createRouteUrl mock
-    (createRouteUrl as Mock).mockReturnValue('https://app.example.com/callback?code=mock-code&state=mock-state');
+    // Setup createCallbackUrl mock
+    (createCallbackUrl as Mock).mockReturnValue('https://app.example.com/callback?code=mock-code&state=mock-state');
   });
 
   afterEach(() => {
@@ -204,6 +204,42 @@ describe('callback middleware', () => {
     it('should throw the error', () => {
       expect(err).toBeDefined();
       expect(err.message).toBe('The authorization code is invalid or expired');
+    });
+  });
+
+  describe('when behind a reverse proxy with wrong protocol/host', () => {
+    beforeEach(async () => {
+      // Simulate request seen by Hono as http (from proxy) with internal host
+      mockContext.req.url = 'http://internal-host:8080/callback?code=auth-code&state=state-value';
+
+      // createCallbackUrl should be called to use baseURL's origin instead
+      (createCallbackUrl as Mock).mockReturnValue(
+        'https://app.example.com/callback?code=auth-code&state=state-value'
+      );
+
+      mockClient.completeInteractiveLogin.mockResolvedValue({
+        appState: { returnTo: '/' },
+      });
+
+      await callback()(mockContext, nextFn);
+    });
+
+    it('should call createCallbackUrl with request URL and baseURL', () => {
+      expect(createCallbackUrl).toHaveBeenCalledWith('http://internal-host:8080/callback?code=auth-code&state=state-value', 'https://app.example.com');
+    });
+
+    it('should pass the corrected URL (with baseURL origin) to completeInteractiveLogin', () => {
+      expect(mockClient.completeInteractiveLogin).toHaveBeenCalledWith(
+        'https://app.example.com/callback?code=auth-code&state=state-value',
+        mockContext
+      );
+    });
+
+    it('should ensure redirect_uri protocol matches baseURL (https not http)', () => {
+      const callArgs = (mockClient.completeInteractiveLogin as Mock).mock.calls[0];
+      const urlPassedToClient = callArgs[0];
+      expect(urlPassedToClient).toMatch(/^https:\/\/app\.example\.com/);
+      expect(urlPassedToClient).not.toMatch(/^http:\/\//);
     });
   });
 });

--- a/test/utils/util.test.ts
+++ b/test/utils/util.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { createCallbackUrl } from '../../src/utils/util';
+
+describe('createCallbackUrl', () => {
+  describe('when baseURL has correct protocol and host', () => {
+    it('should preserve baseURL origin even when request URL has wrong protocol', () => {
+      const requestUrl = 'http://internal-proxy-host:8080/callback?code=auth-code&state=state-123';
+      const baseURL = 'https://app.example.com';
+
+      const result = createCallbackUrl(requestUrl, baseURL).href;
+
+      // Should use baseURL's origin (https://app.example.com)
+      expect(result).toBe('https://app.example.com/callback?code=auth-code&state=state-123');
+      // Ensure http is NOT in result
+      expect(result).not.toMatch(/^http:\/\//);
+    });
+
+    it('should preserve request pathname and search params', () => {
+      const requestUrl = 'http://wrong-host/callback?code=my-code&state=my-state&extra=param';
+      const baseURL = 'https://app.example.com';
+
+      const result = createCallbackUrl(requestUrl, baseURL).href;
+
+      expect(result).toBe('https://app.example.com/callback?code=my-code&state=my-state&extra=param');
+    });
+
+    it('should handle baseURL with port', () => {
+      const requestUrl = 'http://localhost:3000/callback?code=code&state=state';
+      const baseURL = 'https://api.prod.com:8443';
+
+      const result = createCallbackUrl(requestUrl, baseURL).href;
+
+      expect(result).toBe('https://api.prod.com:8443/callback?code=code&state=state');
+    });
+
+    it('should handle request URL with port and baseURL without explicit port', () => {
+      const requestUrl = 'http://127.0.0.1:9999/callback?code=xyz';
+      const baseURL = 'https://myapp.io';
+
+      const result = createCallbackUrl(requestUrl, baseURL).href;
+
+      expect(result).toBe('https://myapp.io/callback?code=xyz');
+    });
+
+    it('should handle complex pathname', () => {
+      const requestUrl = 'http://internal/auth/oidc/callback?code=abc&state=def';
+      const baseURL = 'https://example.com/myapp';
+
+      const result = createCallbackUrl(requestUrl, baseURL).href;
+
+      expect(result).toBe('https://example.com/auth/oidc/callback?code=abc&state=def');
+    });
+
+    it('should preserve empty search params', () => {
+      const requestUrl = 'http://wrong-host/callback';
+      const baseURL = 'https://app.com';
+
+      const result = createCallbackUrl(requestUrl, baseURL).href;
+
+      expect(result).toBe('https://app.com/callback');
+    });
+
+    it('should match redirect_uri sent at login start', () => {
+      // Simulate: login started with baseURL -> redirect_uri stored
+      // Then callback comes through proxy with wrong protocol/host
+      // This test ensures callback URL matches what was registered at login
+
+      const baseURL = 'https://app.example.com';
+
+      // URL registered at login start (from baseURL)
+      const loginRedirectUri = `${new URL(baseURL).origin}/callback`;
+
+      // URL seen at callback via proxy
+      const proxyRequestUrl = 'http://internal-service:8080/callback?code=auth-code&state=state';
+
+      // createCallbackUrl should produce the same redirect_uri
+      const callbackUrl = createCallbackUrl(proxyRequestUrl, baseURL).href;
+
+      expect(callbackUrl).toMatch(/^https:\/\/app\.example\.com\/callback/);
+      expect(callbackUrl.split('?')[0]).toBe(loginRedirectUri);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #13 — login fails behind a reverse proxy / AWS ALB that terminates TLS.

The callback handler built the completion URL from `c.req.url` (absolute). `new URL(absolute, base)` ignores the base, so the proxy's wrong protocol (`http`) and host leaked into the computed `redirect_uri`, which then mismatched the one sent at login start and broke the token exchange.

Adds `createCallbackUrl(requestUrl, baseURL)`: rebuilds the URL from `baseURL`'s origin (protocol + host + port) plus the request's pathname + search, returning a `URL` to match `completeInteractiveLogin(url: URL)`. `toSafeRedirect` open-redirect protection is unchanged.

## Test plan
- [x] `npm test` — 349 passed (added util + callback proxy-scenario tests)
- [x] `npm run build`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)